### PR TITLE
fix FRR config of SRv6-AI-Backend node 02T1

### DIFF
--- a/use-cases/SRv6-AI-Backend/config/02T1/frr.conf
+++ b/use-cases/SRv6-AI-Backend/config/02T1/frr.conf
@@ -11,8 +11,8 @@ zebra nexthop-group keep 1
 !
 ipv6 route fcbb:bbbb:1::/48 2001:db8:1:1002::1 Ethernet0
 ipv6 route fcbb:bbbb:2::/48 2001:db8:2:1002::2 Ethernet4
-ipv6 route fcbb:bbbb:A001::/48 2001:db8:1:1001::1 Ethernet0
-ipv6 route fcbb:bbbb:B001::/48 2001:db8:1:1002::1 Ethernet4
+ipv6 route fcbb:bbbb:A001::/48 2001:db8:1:1002::1 Ethernet0
+ipv6 route fcbb:bbbb:B001::/48 2001:db8:2:1002::2 Ethernet4
 !
 segment-routing
  srv6


### PR DESCRIPTION
For the AI backend use case, the FRR static routes to NIC-A and NIC-B on node 02T1 are incorrect